### PR TITLE
remove reference to nonexistent module

### DIFF
--- a/texrunner.cabal
+++ b/texrunner.cabal
@@ -47,8 +47,6 @@ test-suite tests
   main-is:        Tests.hs
   ghc-options:    -Wall
   default-language: Haskell2010
-  other-modules:
-    Tex.PDF
 
   build-depends:
     base,


### PR DESCRIPTION
Tex.PDF does not seem to exist.  Causes errors for me while building diagrams-pgf.